### PR TITLE
Fix cron day-of-month range

### DIFF
--- a/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
@@ -70,7 +70,7 @@ export const toCronExpression = (interval: ScheduleInterval): CronExpression => 
 		return `${randomSecond} ${minute} ${hour} * * ${daysOfWeek}` as CronExpression;
 	}
 
-	const dayOfMonth = interval.triggerAtDayOfMonth ?? randomInt(0, 31);
+	const dayOfMonth = interval.triggerAtDayOfMonth ?? randomInt(1, 32);
 	return `${randomSecond} ${minute} ${hour} ${dayOfMonth} */${interval.monthsInterval} *`;
 };
 


### PR DESCRIPTION
## Summary
- ensure random day-of-month is 1..31 when generating cron expressions

## Testing
- `pnpm exec jest nodes/Schedule/test/GenericFunctions.test.ts` *(fails: Cannot find module 'n8n-workflow')*


------
https://chatgpt.com/codex/tasks/task_b_68883625daf4832187d3fe76559fd721