### PR TITLE
refactor: rename ssh tunnel key fields

### DIFF
--- a/packages/core/src/execution-engine/ssh-clients-manager.ts
+++ b/packages/core/src/execution-engine/ssh-clients-manager.ts
@@ -34,8 +34,8 @@ export class SSHClientsManager {
 			...(sshAuthenticateWith === 'password'
 				? { password: credentials.sshPassword }
 				: {
-						privateKey: credentials.privateKey,
-						passphrase: credentials.passphrase ?? undefined,
+						privateKey: credentials.sshPrivateKey,
+						passphrase: credentials.sshPassphrase ?? undefined,
 					}),
 		};
 

--- a/packages/nodes-base/nodes/MySql/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/MySql/v2/transport/index.ts
@@ -64,8 +64,8 @@ export async function createPool(
 	if (!credentials.sshTunnel) {
 		return mysql2.createPool(connectionOptions);
 	} else {
-		if (credentials.sshAuthenticateWith === 'privateKey' && credentials.privateKey) {
-			credentials.privateKey = formatPrivateKey(credentials.privateKey);
+		if (credentials.sshAuthenticateWith === 'privateKey' && credentials.sshPrivateKey) {
+			credentials.sshPrivateKey = formatPrivateKey(credentials.sshPrivateKey);
 		}
 		const sshClient = await this.helpers.getSSHClient(credentials);
 

--- a/packages/nodes-base/nodes/Postgres/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/transport/index.ts
@@ -98,8 +98,8 @@ export async function configurePostgres(
 
 			return { db, pgp };
 		} else {
-			if (credentials.sshAuthenticateWith === 'privateKey' && credentials.privateKey) {
-				credentials.privateKey = formatPrivateKey(credentials.privateKey);
+			if (credentials.sshAuthenticateWith === 'privateKey' && credentials.sshPrivateKey) {
+				credentials.sshPrivateKey = formatPrivateKey(credentials.sshPrivateKey);
 			}
 			const sshClient = await this.helpers.getSSHClient(credentials);
 

--- a/packages/nodes-base/utils/sshTunnel.properties.ts
+++ b/packages/nodes-base/utils/sshTunnel.properties.ts
@@ -78,7 +78,7 @@ export const sshTunnelProperties: INodeProperties[] = [
 	},
 	{
 		displayName: 'Private Key',
-		name: 'privateKey', // TODO: Rename to sshPrivateKey
+		name: 'sshPrivateKey',
 		type: 'string',
 		typeOptions: {
 			rows: 4,
@@ -94,7 +94,7 @@ export const sshTunnelProperties: INodeProperties[] = [
 	},
 	{
 		displayName: 'Passphrase',
-		name: 'passphrase', // TODO: Rename to sshPassphrase
+		name: 'sshPassphrase',
 		type: 'string',
 		default: '',
 		description: 'Passphrase used to create the key, if no passphrase was used leave empty',

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -821,10 +821,8 @@ export type SSHCredentials = {
 	  }
 	| {
 			sshAuthenticateWith: 'privateKey';
-			// TODO: rename this to `sshPrivateKey`
-			privateKey: string;
-			// TODO: rename this to `sshPassphrase`
-			passphrase?: string;
+			sshPrivateKey: string;
+			sshPassphrase?: string;
 	  }
 );
 


### PR DESCRIPTION
## Summary
- rename `privateKey` to `sshPrivateKey` and `passphrase` to `sshPassphrase`
- update Postgres and MySQL transports to use new SSH tunnel fields
- adjust SSH client manager and workflow interfaces

## Testing
- `pnpm test --filter n8n-workflow`
- `pnpm test --filter n8n-core` *(fails: Unable to resolve path to module '../../../nodes-base/dist/nodes/If/If.node')*
- `pnpm test --filter n8n-nodes-base` *(fails: Unable to resolve path to module '../core/nodes-testing/node-test-harness.ts')*

------
https://chatgpt.com/codex/tasks/task_b_6890117896b08321b8e2b5e984502a29